### PR TITLE
DM-24654: Add licensing headers to everything in alert-stream-simulator, and test for such headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,23 +10,38 @@ on:
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  # The test job runs unit tests - anything that doesn't depend on a real broker
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
 
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install program, including any dev dependencies
+      run: pip install '.[dev]'
+
+    - name: Run tests
+      run: make test
+
+  # The integration-test job runs integration tests which actually talk to a
+  # kafka broker
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
     - name: Run docker-compose up
       run: docker-compose up -d
-
     - name: Check that containers are up
       run: docker ps -a
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2020 University of Washington

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	python -m unittest

--- a/python/bin/rubin-alert-sim
+++ b/python/bin/rubin-alert-sim
@@ -1,4 +1,26 @@
 #!/usr/bin/env python
+
+# This file is part of rubin-alert-stream.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from streamsim import commands
 
 

--- a/python/streamsim/__init__.py
+++ b/python/streamsim/__init__.py
@@ -1,0 +1,20 @@
+# This file is part of rubin-alert-stream.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/python/streamsim/commands.py
+++ b/python/streamsim/commands.py
@@ -1,3 +1,24 @@
+# This file is part of rubin-alert-stream.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import argparse
 import logging
 

--- a/python/streamsim/sender.py
+++ b/python/streamsim/sender.py
@@ -1,3 +1,23 @@
+# This file is part of rubin-alert-stream.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
 import confluent_kafka
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of alert-stream-simulator.
+# This file is part of rubin-alert-stream.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,20 @@
+# This file is part of alert-stream-simulator.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test/test_license_headers.py
+++ b/test/test_license_headers.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+
+LICENSE_PREAMBLE = """# This file is part of rubin-alert-stream.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+class TestLicenseHeaders(unittest.TestCase):
+    def testFilesHaveLicenseHeader(self):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        py_files = self.gather_python_files(os.path.join(repo_root, "python"))
+        py_files += self.gather_python_files(os.path.join(repo_root, "test"))
+
+        for filename in py_files:
+            if not self.file_contains(filename, LICENSE_PREAMBLE):
+                self.fail(f"{filename} is missing licensing header")
+
+    @staticmethod
+    def gather_python_files(source_dir):
+        """Traverse source_dir and all subdirectories looking for files that end with
+        .py. Put their filenames all in a list and return it.
+        """
+
+        python_files = []
+        for (dirpath, _, filenames) in os.walk(source_dir):
+            for filename in filenames:
+                if filename.endswith(".py"):
+                    python_files.append(os.path.join(dirpath, filename))
+        return python_files
+
+    @staticmethod
+    def file_contains(filename, substring):
+        """ Returns true iff the file at filename contains substring."""
+        with open(filename, "r") as fp:
+            contents = fp.read()
+            return substring in contents
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I forgot to do this. I'll keep forgetting to do this unless I write a test.

The test only checks `.py` files, not YAML docker configuration files or anything else. I think that's acceptable.

Putting headers in blank `__init__.py` feels a little odd, but I do it anyway because I guess it can't hurt.