### PR TITLE
Use correct project name in license headers

### DIFF
--- a/python/streamsim/__init__.py
+++ b/python/streamsim/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of rubin-alert-stream.
+# This file is part of alert-stream-simulator.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/streamsim/commands.py
+++ b/python/streamsim/commands.py
@@ -1,4 +1,4 @@
-# This file is part of rubin-alert-stream.
+# This file is part of alert-stream-simulator.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/streamsim/sender.py
+++ b/python/streamsim/sender.py
@@ -1,4 +1,4 @@
-# This file is part of rubin-alert-stream.
+# This file is part of alert-stream-simulator.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of rubin-alert-stream.
+# This file is part of alert-stream-simulator.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/test/test_license_headers.py
+++ b/test/test_license_headers.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-LICENSE_PREAMBLE = """# This file is part of rubin-alert-stream.
+LICENSE_PREAMBLE = """# This file is part of alert-stream-simulator.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project


### PR DESCRIPTION
Run `sed -i "s/rubin-alert-stream\./alert-stream-simulator\./g" ./**/*.py` to change all license headers to refer to this project correctly.

Thanks for pointing this out in https://github.com/lsst-dm/alert-stream-simulator/pull/3#issuecomment-623492975 @jdswinbank.