### PR TITLE
DM-24941: Provide a better sample dataset for alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install snappy
-      run: apt-get install libsnappy-dev
+      run: sudo apt-get install libsnappy-dev
 
     - name: Install program, including any dev dependencies
       run: pip install '.[dev]'
@@ -49,7 +49,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install snappy
-      run: apt-get install libsnappy-dev
+      run: sudo apt-get install libsnappy-dev
 
     - name: Install rubin-alert-sim program
       run: pip install .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install snappy
+      run: apt-get install libsnappy-dev
 
     - name: Install program, including any dev dependencies
       run: pip install '.[dev]'
@@ -45,6 +47,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install snappy
+      run: apt-get install libsnappy-dev
 
     - name: Install rubin-alert-sim program
       run: pip install .[dev]

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ lint:
 	flake8
 
 .PHONY: datasets
-datasets: data/rubin_single_ccd_sample.avro data/rubin_single_exposure_sample.avro
+datasets: data/rubin_single_ccd_sample.avro data/rubin_single_visit_sample.avro
 
 data:
 	mkdir -p data
 
 data/rubin_single_ccd_sample.avro: data
-	curl "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/ap_verify_hits2015/42160601.avro" > data/rubin_single_ccd_sample.avro
+	curl --fail "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/rubin_single_ccd_sample.avro" > data/rubin_single_ccd_sample.avro
 
-data/rubin_single_exposure_sample.avro: data
-	curl "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/sample_10k_alerts.avro" > data/rubin_single_exposure_sample.avro
+data/rubin_single_visit_sample.avro: data
+	curl --fail "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/rubin_single_visit_sample.avro" > data/rubin_single_visit_sample.avro

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ lint:
 	flake8
 
 .PHONY: datasets
-datasets: data/rubin_sample.avro
+datasets: data/rubin_single_ccd_sample.avro data/rubin_single_exposure_sample.avro
 
 data:
 	mkdir -p data
 
-data/rubin_sample.avro: data
-	curl "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/ap_verify_hits2015/42160601.avro" > data/rubin_sample.avro
+data/rubin_single_ccd_sample.avro: data
+	curl "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/ap_verify_hits2015/42160601.avro" > data/rubin_single_ccd_sample.avro
+
+data/rubin_single_exposure_sample.avro: data
+	curl "https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/sample_10k_alerts.avro" > data/rubin_single_exposure_sample.avro

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ the "State" of all containers::
 
 If the infrastructure is up, we can create a stream::
 
-  $ rubin-alert-sim create-stream --dst-topic=rubin_example data/rubin_sample.avro
+  $ rubin-alert-sim create-stream --dst-topic=rubin_example data/rubin_single_ccd_sample.avro
   successfully preloaded stream with 792 alerts
 
 And now we can replay that stream::

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Before starting, you'll need:
  - Docker
  - `docker-compose <https://docs.docker.com/compose/>`_
  - curl
+ - `libsnappy <https://github.com/google/snappy>`_ (`apt-get install libsnappy-dev` / `yum install libsnappy-devel`)
 
 Clone the repository, activate a virtualenv (or whatever Python env isolation
 mechanism you prefer), and then run ``make install``. Go get a cup of coffee while
@@ -49,7 +50,7 @@ the "State" of all containers::
   $ docker-compose ps
   Name                             Command               State   Ports
   -----------------------------------------------------------------------------------
-  alert-stream-simulator_grafana_1     /run.sh                          Up
+  Alert-stream-simulator_grafana_1     /run.sh                          Up
   alert-stream-simulator_influxdb_1    /entrypoint.sh /etc/influx ...   Up
   alert-stream-simulator_jmxtrans_1    /bin/sh -c /usr/share/jmxt ...   Up
   alert-stream-simulator_kafka_1       /etc/confluent/docker/run        Up

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Before starting, you'll need:
  - Docker
  - `docker-compose <https://docs.docker.com/compose/>`_
  - curl
- - `libsnappy <https://github.com/google/snappy>`_ (`apt-get install libsnappy-dev` / `yum install libsnappy-devel`)
+ - `libsnappy <https://github.com/google/snappy>`_ (`apt-get install libsnappy-dev` / `yum install snappy-devel`)
 
 Clone the repository, activate a virtualenv (or whatever Python env isolation
 mechanism you prefer), and then run ``make install``. Go get a cup of coffee while

--- a/script/build_sample_datasets.sh
+++ b/script/build_sample_datasets.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set +xeo pipefail
+
+# Little script for constructing sample datasets on lsst-dev servers. Should be
+# run with the alert-stream-simulator's 'scripts' directory in $PATH, and with
+# fastavro and python-snappy Python packages installed.
+
+combine_avro.py "/project/morriscb/src/ap_verify_hits2015/alerts/421590*.avro" visit_421590.avro
+
+cp /project/morriscb/src/ap_verify_hits2015/alerts/42160601.avro ccdvisit_42160601.avro
+snappy_recompress.py ccdvisit_42160601.avro ccdvisit_42160601_snappy.avro
+rm ccdvisit_42160601.avro
+
+PUBLIC_DIR=/home/swnelson/public_html/alert-stream-simulator
+
+mv visit_421590.avro $PUBLIC_DIR/rubin_single_visit_sample.avro
+mv ccdvisit_42160601_snappy.avro $PUBLIC_DIR/rubin_single_ccd_sample.avro

--- a/script/combine_avro.py
+++ b/script/combine_avro.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import fastavro
+import sys
+import glob
+import itertools
+
+
+def combine(input_glob, output_filepath):
+    readers = []
+    for in_file_path in glob.glob(input_glob):
+        infile = open(in_file_path, "rb")
+        readers.append(fastavro.reader(infile))
+    combined_reader = itertools.chain(*readers)
+    with open(output_filepath, "a+") as outfile:
+        fastavro.writer(outfile, readers[0].writer_schema,
+                        combined_reader, codec="snappy")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: combine_avro.py INPUT_GLOB OUTPUT")
+        print("    combines all avro files that match INPUT_GLOB into one file at OUTPUT")
+        sys.exit(1)
+    combine(sys.argv[1], sys.argv[2])

--- a/script/count_per_visit.py
+++ b/script/count_per_visit.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import fastavro
+import sys
+import collections
+
+
+def count(input_filename):
+    counts = collections.defaultdict(int)
+    with open(input_filename, "rb") as infile:
+        reader = fastavro.reader(infile)
+        for m in reader:
+            counts[m['diaSource']['midPointTai']] += 1
+    for visit_id in sorted(counts, key=lambda id: counts[id]):
+        print(visit_id, counts[visit_id])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: count_per_mid_point_tai.py INPUT")
+        print("    counts the number of alerts per midPointTai in INPUT")
+        sys.exit(1)
+    count(sys.argv[1])

--- a/script/filter_by_midpoint_tai.py
+++ b/script/filter_by_midpoint_tai.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import fastavro
+import sys
+import glob
+
+
+def run_filter(input_filename, output_filename, filter_tai):
+    with open(input_filename, "rb") as input_fp:
+        reader = fastavro.reader(input_fp)
+        filtered_reader = filter(
+            lambda alert: alert['diaSource']['midPointTai'] == filter_tai,
+            reader
+        )
+        with open(output_filename, "ab") as output_fp:
+            fastavro.writer(
+                fo=output_fp,
+                schema=reader.writer_schema,
+                records=filtered_reader,
+                codec=reader.codec,
+            )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("usage: filter_by_midpoint_tai.py INPUT OUTPUT TAI")
+        print("    copies all alerts with given TAI in INPUT to OUTPUT")
+        sys.exit(1)
+    run_filter(sys.argv[1], sys.argv[2], float(sys.argv[3]))

--- a/script/filter_by_midpoint_tai.py
+++ b/script/filter_by_midpoint_tai.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import fastavro
 import sys
-import glob
 
 
 def run_filter(input_filename, output_filename, filter_tai):

--- a/script/snappy_recompress.py
+++ b/script/snappy_recompress.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import fastavro
+import sys
+
+
+def recompress(input_filename, output_filename):
+    with open(input_filename, "rb") as infile:
+        reader = fastavro.reader(infile)
+
+        with open(output_filename, "wb") as outfile:
+            fastavro.writer(outfile, reader.writer_schema, reader,
+                            codec="snappy")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: snappy_recompress.py INPUT OUTPUT")
+        print("    reserializes INPUT to OUTPUT, compressing the avro stream with snappy")
+        sys.exit(1)
+
+    recompress(sys.argv[1], sys.argv[2])

--- a/script/truncate.py
+++ b/script/truncate.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import fastavro
+import sys
+import itertools
+
+
+def truncate(input_filename, output_filename, n):
+    with open(input_filename, "rb") as infile:
+        reader = fastavro.reader(infile)
+
+        partial_reader = itertools.islice(reader, n)
+        with open(output_filename, "wb") as outfile:
+            fastavro.writer(outfile, reader.writer_schema,
+                            partial_reader, codec=reader.codec)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("usage: truncate.py INPUT OUTPUT N")
+        print("    copy the first N alerts from INPUT to OUTPUT")
+        sys.exit(1)
+
+    truncate(sys.argv[1], sys.argv[2], int(sys.argv[3]))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-install_requires = ['avro-python3', 'confluent_kafka', 'astropy', 'fastavro']
+install_requires = ['avro-python3', 'confluent_kafka', 'astropy', 'fastavro', 'python-snappy']
 
 dev_requires = ['pytest', 'pytest-integration', 'flake8', 'pep8-naming']
 


### PR DESCRIPTION
This PR changes the Makefile to download a more-complete dataset for passing through the simulator. This new dataset is the output across all CCDs for one HITS visit. It contains 10,728 alerts, verifiable by running `count_per_visity.py` on `data/rubin_single_visit_sample.avro` (after running `make datasets`).

I included the scripts I used to create the data and put it on lsst-dev. It's stored in my personal public_html directory, so it shows up on the web at https://lsst-web.ncsa.illinois.edu/~swnelson/alert-stream-simulator/.