### PR TITLE
DM-24966: Raise Kafka errors as exceptions, not errors

### DIFF
--- a/python/streamsim/_kafka.py
+++ b/python/streamsim/_kafka.py
@@ -47,7 +47,7 @@ def _error_callback(kafka_error):
         logger.warn("client is currently disconnected from all brokers")
     else:
         logger.error(f"internal kafka error: {kafka_error}")
-        raise(kafka_error)
+        raise(confluent_kafka.KafkaException(kafka_error))
 
 
 class _KafkaClient(object):
@@ -303,7 +303,7 @@ class _KafkaClient(object):
                         # Done with all partitions for the topic, remove it
                         del active_partitions[m.topic()]
                 else:
-                    raise(err)
+                    raise(confluent_kafka.KafkaException(err))
 
 
 def _is_topic_exists_error(kafka_exception):


### PR DESCRIPTION
#### Ticket:
[DM-24966](https://jira.lsstcorp.org/browse/DM-24966)

The current code tries to `raise` confluent_kafka.KafkaError values. This is not quite right. The raisable one is a `confluent_kafka.KafkaException`. We should wrap errors in the Exception class before raising them.