### PR TITLE
DM-24967: Fix flake8 errors in alert-stream-simulator

### DIFF
--- a/python/streamsim/_kafka.py
+++ b/python/streamsim/_kafka.py
@@ -175,7 +175,7 @@ class _KafkaClient(object):
                 return res
             except confluent_kafka.KafkaException as e:
                 if _is_topic_exists_error(e):
-                    logger.debug(f"topic exists, deleting and retrying")
+                    logger.debug("topic exists, deleting and retrying")
                     try:
                         self.delete_topic(topic)
                     except confluent_kafka.KafkaException as delete_exc:


### PR DESCRIPTION
#### Ticket:
[DM-24967](https://jira.lsstcorp.org/browse/DM-24967)

The new flake8 update has caused some minor whinging in alert-stream-simulator's lint job. We should fix this.