### PR TITLE
Add --repeat-interval argument for playing a stream continuously

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,14 +65,16 @@ And now we can replay that stream::
 
   $ rubin-alert-sim --verbose play-stream \
       --src-topic=rubin_example \
-      --dst-topic=rubin_example_stream
+      --dst-topic=rubin_example_stream \
+      --repeat-interval=37
   INFO:rubin-alert-sim.play:sent 792 alerts in 1.67s (474.58/s)
 
-This second command is worth looking at closely. We set the ``--dst-topi`` to
+This second command is worth looking at closely. We set the ``--dst-topic`` to
 ``rubin_example_stream``: this will create a new topic with that name, and will
 pace the data into it at the same rate as we had set with ``create-stream``.
-Connect your consumers to the ``--dst-topic`` to simulate receiving Rubin's
-alerts.
+This data will be repeated every 37 seconds, which is set with the
+``--repeat-interval=37`` line. Connect your consumers to the ``--dst-topic`` to
+simulate receiving Rubin's alerts.
 
 
 Writing your own consumer

--- a/python/streamsim/commands.py
+++ b/python/streamsim/commands.py
@@ -44,7 +44,7 @@ def run():
     elif args.subcommand == "play-stream":
         logging.debug(f"dispatching play-stream command with args: {args}")
         n = player.play(args.broker, args.src_topic, args.dst_topic, args.dst_topic_partitions,
-                        args.force)
+                        args.force, args.repeat_interval)
         print(f"played {n} alerts from the stream")
     elif args.subcommand == "print-stream":
         logging.debug(f"dispatching print-stream command with args: {args}")
@@ -116,6 +116,10 @@ def construct_argparser():
     )
     play_cmd.add_argument(
         "--force", action="store_true", help="overwrite dst-topic if it already exists",
+    )
+    play_cmd.add_argument(
+        "--repeat-interval", type=int, default=-1,
+        help="interval to repeat the stream, in seconds. <0 means don't repeat",
     )
 
     print_cmd = subparsers.add_parser(

--- a/python/streamsim/player.py
+++ b/python/streamsim/player.py
@@ -22,13 +22,13 @@ import logging
 import datetime
 import time
 
-from streamsim import _kafka, timestamps
+from streamsim import _kafka, serialization
 
 
 logger = logging.getLogger("rubin-alert-sim.play")
 
 
-def play(broker, src_topic, dst_topic, dst_topic_partitions, force):
+def play(broker, src_topic, dst_topic, dst_topic_partitions, force, repeat_interval=-1):
     """Replays an existing alert stream in the broker, copying it from
     src_topic to dst_topic while obeying time offset headers.
 
@@ -63,19 +63,38 @@ def play(broker, src_topic, dst_topic, dst_topic_partitions, force):
     logger.debug(f"subscribing to topic {src_topic}")
     kafka_client.subscribe(src_topic)
 
-    start = datetime.datetime.now()
-    n = 0
-    for msg in kafka_client.iterate():
-        since_start = datetime.datetime.now() - start
-        offset = timestamps.get_message_time_offset(msg)
-        if since_start < offset:
-            time.sleep((offset - since_start).total_seconds())
+    n_total = 0
+    while True:
+        start = datetime.datetime.now()
+        n = 0
+        for msg in kafka_client.iterate():
+            since_start = datetime.datetime.now() - start
+            offset = serialization.get_message_time_offset(msg)
+            if since_start < offset:
+                time.sleep((offset - since_start).total_seconds())
 
-        logger.debug(f"sending message of size {len(msg)}")
-        kafka_client.producer.produce(dst_topic, msg.value())
+            logger.debug(f"sending message of size {len(msg)}")
+            kafka_client.producer.produce(dst_topic, msg.value())
 
-        n += 1
+            n += 1
+        kafka_client.producer.flush()
+        n_total += n
+
+        if repeat_interval < 0:
+            break
+
+        since_start_sec = (datetime.datetime.now() - start).total_seconds()
+        logger.info(f"sent {n} alerts in {since_start_sec:.2f}s ({n / since_start_sec:.2f}/s)")
+
+        if since_start_sec < repeat_interval:
+            logger.info(f"going to sleep for {repeat_interval - since_start_sec:.2f}s")
+
+            time.sleep(repeat_interval - since_start_sec)
+        else:
+            logger.warn(f"unable to keep up with repeat interval: took {since_start_sec}s to run"
+                        + ", interval is {repeat_interval}")
+        kafka_client.seek_to_beginning()
 
     kafka_client.close()
 
-    return n
+    return n_total

--- a/python/streamsim/player.py
+++ b/python/streamsim/player.py
@@ -22,7 +22,7 @@ import logging
 import datetime
 import time
 
-from streamsim import _kafka, serialization
+from streamsim import _kafka, timestamps
 
 
 logger = logging.getLogger("rubin-alert-sim.play")
@@ -69,7 +69,7 @@ def play(broker, src_topic, dst_topic, dst_topic_partitions, force, repeat_inter
         n = 0
         for msg in kafka_client.iterate():
             since_start = datetime.datetime.now() - start
-            offset = serialization.get_message_time_offset(msg)
+            offset = timestamps.get_message_time_offset(msg)
             if since_start < offset:
                 time.sleep((offset - since_start).total_seconds())
 


### PR DESCRIPTION
This was in the demo I showed off, but I missed adding it. It will let a user continuously repeat a stream that's been loaded into Kafka, which is probably the common-case operating mode. You use it like `rubin-alert-sim play-stream --repeat-interval=1`.

This code works, it just had been sitting around locally for a month. Oops.